### PR TITLE
Initialize i18n before app render

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import i18n from './i18n';
 import App from './App.jsx';
 import './index.css';
+
+document.documentElement.setAttribute('lang', i18n.language || 'en');
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- import the i18n initializer in the main entry point
- set the document language attribute before rendering so i18n is ready

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e028939eec8328ae5ca8935d68f3af