### PR TITLE
Add header language switcher and navigation translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lucide-react": "^0.441.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.26.0"
+    "react-router-dom": "^6.26.0",
+    "i18next": "^23.11.5",
+    "react-i18next": "^14.1.2"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.0",

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
-
-const navLinks = [
-  { name: 'Home', to: '/' },
-  { name: 'Services', to: '/services' },
-  { name: 'Case studies', to: '/cases' },
-  { name: 'Articles', to: '/articles' },
-  { name: 'About', to: '/about' },
-  { name: 'Contact', to: '/contact' },
-];
+import { useTranslation } from 'react-i18next';
+import LanguageSwitcher from './LanguageSwitcher.jsx';
 
 const Header = () => {
   const location = useLocation();
+  const { t } = useTranslation();
+
+  const navLinks = [
+    { key: 'home', to: '/' },
+    { key: 'services', to: '/services' },
+    { key: 'cases', to: '/cases' },
+    { key: 'articles', to: '/articles' },
+    { key: 'about', to: '/about' },
+    { key: 'contact', to: '/contact' },
+  ];
 
   return (
     <header className="sticky top-0 z-40 bg-[#0c0d10bf] backdrop-blur-xl border-b border-white/5">
@@ -21,45 +24,48 @@ const Header = () => {
           <div className="h-10 w-10 rounded-3xl bg-gold bg-[length:160%] bg-center shadow-lg shadow-brand/25" aria-hidden />
           <span className="font-semibold tracking-tight text-lg">ITechWise</span>
         </Link>
-        <nav aria-label="Main navigation" className="hidden md:flex items-center gap-6 text-sm">
-          {navLinks.map((link) => (
-            <NavLink
-              key={link.name}
-              to={link.to}
-              className={({ isActive }) =>
-                `relative transition text-muted hover:text-text pb-1 ${
-                  isActive || location.pathname.startsWith(link.to) && link.to !== '/'
-                    ? 'text-text'
-                    : ''
-                }`
-              }
-              end={link.to === '/'}
+        <nav aria-label="Main navigation" className="hidden md:flex items-center gap-8 text-sm">
+          <div className="flex items-center gap-6">
+            {navLinks.map((link) => (
+              <NavLink
+                key={link.to}
+                to={link.to}
+                className={({ isActive }) =>
+                  `relative transition text-muted hover:text-text pb-1 ${
+                    isActive || (location.pathname.startsWith(link.to) && link.to !== '/')
+                      ? 'text-text'
+                      : ''
+                  }`
+                }
+                end={link.to === '/'}
+              >
+                {({ isActive }) => (
+                  <>
+                    {t(`nav.${link.key}`)}
+                    <span
+                      aria-hidden
+                      className={`absolute left-0 bottom-0 h-[2px] transition-all duration-300 ${
+                        isActive || (location.pathname.startsWith(link.to) && link.to !== '/')
+                          ? 'w-full bg-brand'
+                          : 'w-0 bg-transparent'
+                      }`}
+                    />
+                  </>
+                )}
+              </NavLink>
+            ))}
+          </div>
+          <div className="flex items-center gap-3">
+            <LanguageSwitcher />
+            <Link
+              to="/contact"
+              className="inline-flex items-center gap-2 rounded-full bg-brand text-bg font-medium px-5 py-2.5 shadow-lg shadow-brand/40 hover:bg-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
             >
-              {({ isActive }) => (
-                <>
-                  {link.name}
-                  <span
-                    aria-hidden
-                    className={`absolute left-0 bottom-0 h-[2px] transition-all duration-300 ${
-                      isActive || (location.pathname.startsWith(link.to) && link.to !== '/')
-                        ? 'w-full bg-brand'
-                        : 'w-0 bg-transparent'
-                    }`}
-                  />
-                </>
-              )}
-            </NavLink>
-          ))}
+              {t('nav.cta')}
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
         </nav>
-        <div className="hidden md:flex">
-          <Link
-            to="/contact"
-            className="inline-flex items-center gap-2 rounded-full bg-brand text-bg font-medium px-5 py-2.5 shadow-lg shadow-brand/40 hover:bg-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
-          >
-            Get candidates in 48 hours
-            <ArrowRight className="h-4 w-4" />
-          </Link>
-        </div>
       </div>
     </header>
   );

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -1,0 +1,64 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import i18n, { setLang } from '../lib/i18n.js';
+
+const LANGUAGES = [
+  { code: 'ru', label: 'RU' },
+  { code: 'en', label: 'EN' },
+];
+
+const LanguageSwitcher = () => {
+  const [currentLanguage, setCurrentLanguage] = useState(
+    i18n.language || i18n.resolvedLanguage || LANGUAGES[0].code,
+  );
+
+  useEffect(() => {
+    const handleLanguageChange = (lng) => {
+      setCurrentLanguage(lng);
+    };
+
+    i18n.on('languageChanged', handleLanguageChange);
+    return () => {
+      i18n.off('languageChanged', handleLanguageChange);
+    };
+  }, []);
+
+  const handleSelectLanguage = useCallback(
+    (language) => {
+      if (language !== currentLanguage) {
+        setLang(language);
+      }
+    },
+    [currentLanguage],
+  );
+
+  const buttons = useMemo(
+    () =>
+      LANGUAGES.map(({ code, label }) => {
+        const isActive = currentLanguage === code;
+        return (
+          <button
+            key={code}
+            type="button"
+            onClick={() => handleSelectLanguage(code)}
+            aria-pressed={isActive}
+            className={`relative rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand ${
+              isActive
+                ? 'bg-white text-[#0c0d10] shadow-sm shadow-black/20'
+                : 'text-muted hover:text-text'
+            }`}
+          >
+            {label}
+          </button>
+        );
+      }),
+    [currentLanguage, handleSelectLanguage],
+  );
+
+  return (
+    <div className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/5 p-1 shadow-inner shadow-white/10">
+      {buttons}
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -1,0 +1,73 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const STORAGE_KEY = 'itechwise-language';
+const FALLBACK_LANGUAGE = 'en';
+
+const getStoredLanguage = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return stored || null;
+};
+
+const resources = {
+  en: {
+    translation: {
+      nav: {
+        home: 'Home',
+        services: 'Services',
+        cases: 'Case studies',
+        articles: 'Articles',
+        about: 'About',
+        contact: 'Contact',
+        cta: 'Get candidates in 48 hours',
+      },
+    },
+  },
+  ru: {
+    translation: {
+      nav: {
+        home: 'Главная',
+        services: 'Услуги',
+        cases: 'Кейсы',
+        articles: 'Статьи',
+        about: 'О компании',
+        contact: 'Контакты',
+        cta: 'Получите кандидатов за 48 часов',
+      },
+    },
+  },
+};
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: getStoredLanguage() || FALLBACK_LANGUAGE,
+  fallbackLng: FALLBACK_LANGUAGE,
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+if (typeof window !== 'undefined') {
+  window.document.documentElement.setAttribute('lang', i18n.language);
+}
+
+i18n.on('languageChanged', (lng) => {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, lng);
+    window.document.documentElement.setAttribute('lang', lng);
+  }
+});
+
+export const setLang = (lng) => {
+  if (!lng || lng === i18n.language) {
+    return;
+  }
+
+  i18n.changeLanguage(lng);
+};
+
+export default i18n;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
+import './lib/i18n.js';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- configure i18next with English and Russian navigation translations and expose a setLang helper
- add a LanguageSwitcher component that listens for languageChanged events and toggles RU/EN buttons
- update the header navigation to use translation keys, include the language switcher, and translate the CTA label

## Testing
- npm run build *(fails: missing i18next dependency because the registry request was forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e028a252108328b47430ee517c0a3d