### PR TITLE
Document i18n details in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ npm run dev
 npm run build
 ```
 
-The production build outputs to `dist/` with a top-level `index.html` suitable for Cloudflare Pages.
+The build command remains `npm run build`, and the production output continues to be written to `dist/` with a top-level `index.html` suitable for Cloudflare Pages.
+
+## i18n
+
+- RU (`ru`) and EN (`en`) translations are fully supported.
+- The language toggle lives in the site header and persists the selected locale in `localStorage` so it survives reloads.
+- The `<html lang>` attribute is updated whenever the active language changes.
 
 ## Deploy to Cloudflare Pages
 


### PR DESCRIPTION
## Summary
- add an i18n section noting RU and EN support, the header language switcher, and `<html lang>` updates
- clarify that the build command remains `npm run build` with artifacts in `dist/`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e028a596788328b57b3210134fb9f3